### PR TITLE
Added parse exception handling

### DIFF
--- a/Jwt.php
+++ b/Jwt.php
@@ -73,7 +73,12 @@ class Jwt extends Component
      */
     public function loadToken($token, $validate = true, $verify = true)
     {
-        $token = $this->getParser()->parse((string)$token);
+        try {
+            $token = $this->getParser()->parse((string)$token);
+        } catch (\RuntimeException $e) {
+            Yii::warning("Invalid JWT provided: " . $e->getMessage(), 'jwt');
+            return null;
+        }
 
         if ($validate && !$this->validateToken($token)) {
             return null;


### PR DESCRIPTION
Parsing fails if invalid data provided in token:

```
    "#0 /app/vendor/lcobucci/jwt/src/Parser.php(112): Lcobucci\\JWT\\Parsing\\Decoder->jsonDecode('\\xC8\\x98[\\x19\\xC8\\x8E\\x88\\x92\\x14\\xCDLL\\x88\\x8B\\x08...')",
    "#1 /app/vendor/lcobucci/jwt/src/Parser.php(60): Lcobucci\\JWT\\Parser->parseHeader('yJhbGciOiJIUzUx...')",
    "#2 /app/vendor/sizeg/yii2-jwt/Jwt.php(76): Lcobucci\\JWT\\Parser->parse('yJhbGciOiJIUzUx...')",
    "#3 /app/vendor/sizeg/yii2-jwt/JwtHttpBearerAuth.php(113): sizeg\\jwt\\Jwt->loadToken('yJhbGciOiJIUzUx...')",
    "#4 /app/vendor/sizeg/yii2-jwt/JwtHttpBearerAuth.php(78): sizeg\\jwt\\JwtHttpBearerAuth->loadToken('yJhbGciOiJIUzUx...')",
    "#5 /app/rest/base/JwtBearerAuth.php(22): sizeg\\jwt\\JwtHttpBearerAuth->authenticate(Object(common\\web\\User), Object(yii\\web\\Request), Object(yii\\web\\Response))",
    "#6 /app/vendor/yiisoft/yii2/filters/auth/AuthMethod.php(60): rest\\base\\JwtBearerAuth->authenticate(Object(common\\web\\User), Object(yii\\web\\Request), Object(yii\\web\\Response))",
```

This produces 500 HTTP error