### PR TITLE
Ability to invalidate token (blacklist it)

### DIFF
--- a/Jwt.php
+++ b/Jwt.php
@@ -100,7 +100,7 @@ class Jwt extends Component
             return null;
         }
 
-        if ($checkBlacklist && $this->isInBlacklist($token)) {
+        if ($this->getIsBlacklistEnabled() && $checkBlacklist && $this->isInBlacklist($token)) {
             return null;
         }
 

--- a/Jwt.php
+++ b/Jwt.php
@@ -186,7 +186,7 @@ class Jwt extends Component
      */
     public function getIsBlacklistEnabled()
     {
-        return $this->getBlacklist() !== false;
+        return $this->getBlacklist() instanceof CacheInterface;
     }
 
     /**

--- a/Jwt.php
+++ b/Jwt.php
@@ -160,7 +160,7 @@ class Jwt extends Component
         }
         $exp = $token->getClaim('exp', false);
         $duration = null;
-        if ($exp !== false) {
+        if ($exp !== false && $exp > time()) {
             $duration = $exp - time();
             $duration += 24 * 60 * 60; // Add 24h more, in case if there are some issues with time on server.
         }


### PR DESCRIPTION
Hi,

what about implementing blacklist support?
In my solution we use cache as blacklist storage.

There are two options how you can enable blacklist:
1. by using cache component by it's name
```

'jwt' => [
    'class' => sizeg\jwt\Jwt::class,
    'blacklist' => 'cache',
],
```
2. by configuring it specifically for jwt component
```
'jwt' => [
    'class' => sizeg\jwt\Jwt::class,
    'blacklist' => [
        'class' => \yii\caching\DbCache::class,
        'cacheTable' => 'jwt_blacklist',
    ],
],
```

Then you can invalidate token by passing `Token` instance to `invalidate` function:
`\Yii::$app->jwt->invalidate($token);`