### PR TITLE
Fixed catch InvalidArgumentException in Jwt::loadToken()

### DIFF
--- a/Jwt.php
+++ b/Jwt.php
@@ -124,7 +124,7 @@ class Jwt extends Component
         } catch (\RuntimeException $e) {
             Yii::warning('Invalid JWT provided: ' . $e->getMessage(), 'jwt');
             return null;
-        } catch (InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             Yii::warning('Invalid JWT provided: ' . $e->getMessage(), 'jwt');
             return null;
         }


### PR DESCRIPTION
The Lcobucci\JWT\Parser::parse() method can throws a native PHP InvalidArgumentException, not an yii2\base\InvalidArgumentException