### PR TITLE
Error "Typed property sizeg\\jwt\\Jwt::$constraints must not be accessed before initialization"

### DIFF
--- a/src/Jwt.php
+++ b/src/Jwt.php
@@ -88,7 +88,7 @@ final class Jwt extends Component implements JwtSigner, JwtKey
     /**
      * @var \Lcobucci\JWT\Validation\Constraint[]
      */
-    public array $constraints;
+    public array $constraints = [];
 
     /**
      * @return BuilderInterface


### PR DESCRIPTION
I've got the error "Typed property sizeg\\jwt\\Jwt::$constraints must not be accessed before initialization".

After initialization as an empty array, error no longer seen.